### PR TITLE
Ruby 1.8.7 (MRI) barfs expecting another argument due to trailing comma

### DIFF
--- a/lib/burstsms/messages_add.rb
+++ b/lib/burstsms/messages_add.rb
@@ -13,7 +13,7 @@ module BurstSms
                                     :caller_id => check_valid_sender(from),
                                     :message => encode_msg(message),
                                     :sendtime => (options.has_key?(:sendtime) ? options[:sendtime] : nil),
-                                    :contact_list => (options.has_key?(:contact_list) ? options[:contact_list] : nil),
+                                    :contact_list => (options.has_key?(:contact_list) ? options[:contact_list] : nil)
                                     )
     end
 


### PR DESCRIPTION
Here's the backtrace:

```
SyntaxError: /var/lib/gems/1.8/gems/burstsms-0.1.2/lib/burstsms/messages_add.rb:17: syntax error, unexpected ')'
/var/lib/gems/1.8/gems/burstsms-0.1.2/lib/burstsms/messages_add.rb:20: class definition in method body
/var/lib/gems/1.8/gems/burstsms-0.1.2/lib/burstsms/messages_add.rb:40: syntax error, unexpected $end, expecting kEND
        from /usr/lib/ruby/1.8/rubygems/custom_require.rb:31:in `gem_original_require'
        from /usr/lib/ruby/1.8/rubygems/custom_require.rb:31:in `require'
        from /var/lib/gems/1.8/gems/burstsms-pdf-0.1.2/lib/burstsms.rb:24
        from /usr/lib/ruby/1.8/rubygems/custom_require.rb:36:in `gem_original_require'
        from /usr/lib/ruby/1.8/rubygems/custom_require.rb:36:in `require'
        from (irb):2
        from :0
```
